### PR TITLE
Use `[tokio::test]` to get rid of `futures::executor::block_on`

### DIFF
--- a/nostr_git_remote_helper/src/main.rs
+++ b/nostr_git_remote_helper/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
     match &cli.command {
         Commands::Capabilities() => sub_commands::capabilities::launch(),
         Commands::Placeholder(args) => {
-            futures::executor::block_on(sub_commands::placeholder::launch(&cli, args))
+            sub_commands::placeholder::launch(&cli, args).await
         }
     }
 }

--- a/src/key_handling/users.rs
+++ b/src/key_handling/users.rs
@@ -679,18 +679,18 @@ mod tests {
         mod when_within_caching_time_window {
             use super::*;
 
-            #[test]
-            fn returns_cached_details_without_checking_relays_or_updaing_config() -> Result<()> {
+            #[tokio::test]
+            async fn returns_cached_details_without_checking_relays_or_updaing_config() -> Result<()> {
                 let mut m = MockUserManager::default();
                 let client = generate_mock_client();
                 m.config_manager
                     .expect_load()
                     .returning(|| Ok(generate_standard_config()));
-                let res = futures::executor::block_on(m.get_user(
+                let res = m.get_user(
                     &client,
                     &TEST_KEY_1_KEYS.public_key(),
                     24 * 60 * 60, // within 24 hours
-                ))?;
+                ).await?;
                 assert_eq!(res.metadata.name, "Fred");
                 assert_eq!(res.relays.relays[0].url, "ws://existingread");
                 Ok(())
@@ -700,8 +700,8 @@ mod tests {
         mod returns_userref_with_latest_details_from_events_on_relays {
             use super::*;
 
-            #[test]
-            fn name() -> Result<()> {
+            #[tokio::test]
+            async fn name() -> Result<()> {
                 let mut m = MockUserManager::default();
                 let mut client = generate_mock_client();
                 m.config_manager
@@ -712,17 +712,17 @@ mod tests {
                     .expect_get_events()
                     .returning(|_, _| Ok(vec![generate_test_key_1_metadata_event("fred")]));
 
-                let res = futures::executor::block_on(m.get_user(
+                let res = m.get_user(
                     &client,
                     &TEST_KEY_1_KEYS.public_key(),
                     5 * 60, // 5 mins ago
-                ))?;
+                ).await?;
                 assert_eq!(res.metadata.name, "fred");
                 Ok(())
             }
 
-            #[test]
-            fn name_ignoring_other_users_events() -> Result<()> {
+            #[tokio::test]
+            async fn name_ignoring_other_users_events() -> Result<()> {
                 let mut m = MockUserManager::default();
                 let mut client = generate_mock_client();
                 m.config_manager
@@ -736,17 +736,17 @@ mod tests {
                     ])
                 });
 
-                let res = futures::executor::block_on(m.get_user(
+                let res = m.get_user(
                     &client,
                     &TEST_KEY_1_KEYS.public_key(),
                     5 * 60, // 5 mins ago
-                ))?;
+                ).await?;
                 assert_eq!(res.metadata.name, "fred");
                 Ok(())
             }
 
-            #[test]
-            fn relays() -> Result<()> {
+            #[tokio::test]
+            async fn relays() -> Result<()> {
                 let mut m = MockUserManager::default();
                 let mut client = generate_mock_client();
                 m.config_manager
@@ -760,17 +760,17 @@ mod tests {
                     ])
                 });
 
-                let res = futures::executor::block_on(m.get_user(
+                let res = m.get_user(
                     &client,
                     &TEST_KEY_1_KEYS.public_key(),
                     5 * 60, // 5 mins ago
-                ))?;
+                ).await?;
                 assert_eq!(res.relays.relays, expected_userrelayrefs(),);
                 Ok(())
             }
 
-            #[test]
-            fn relays_ignoring_other_users_events() -> Result<()> {
+            #[tokio::test]
+            async fn relays_ignoring_other_users_events() -> Result<()> {
                 let mut m = MockUserManager::default();
                 let mut client = generate_mock_client();
                 m.config_manager
@@ -788,11 +788,11 @@ mod tests {
                     ])
                 });
 
-                let res = futures::executor::block_on(m.get_user(
+                let res = m.get_user(
                     &client,
                     &TEST_KEY_1_KEYS.public_key(),
                     5 * 60, // 5 mins ago
-                ))?;
+                ).await?;
                 assert_eq!(res.relays.relays, expected_userrelayrefs(),);
                 Ok(())
             }
@@ -801,8 +801,8 @@ mod tests {
         mod saves_updates_to_config {
             use super::*;
 
-            #[test]
-            fn saves_name_to_config() -> Result<()> {
+            #[tokio::test]
+            async fn saves_name_to_config() -> Result<()> {
                 let mut m = MockUserManager::default();
                 let mut client = generate_mock_client();
                 m.config_manager
@@ -817,16 +817,16 @@ mod tests {
                     .expect_get_events()
                     .returning(|_, _| Ok(vec![generate_test_key_1_metadata_event("fred")]));
 
-                futures::executor::block_on(m.get_user(
+                let _ = m.get_user(
                     &client,
                     &TEST_KEY_1_KEYS.public_key(),
                     5 * 60, // 5 mins ago
-                ))?;
+                ).await?;
                 Ok(())
             }
 
-            #[test]
-            fn updates_metadata_created_at() -> Result<()> {
+            #[tokio::test]
+            async fn updates_metadata_created_at() -> Result<()> {
                 let mut m = MockUserManager::default();
                 let mut client = generate_mock_client();
                 m.config_manager
@@ -841,16 +841,16 @@ mod tests {
                     .expect_get_events()
                     .returning(|_, _| Ok(vec![generate_test_key_1_metadata_event("fred")]));
 
-                futures::executor::block_on(m.get_user(
+                let _ = m.get_user(
                     &client,
                     &TEST_KEY_1_KEYS.public_key(),
                     5 * 60, // 5 mins ago
-                ))?;
+                ).await?;
                 Ok(())
             }
 
-            #[test]
-            fn saves_relays_to_config() -> Result<()> {
+            #[tokio::test]
+            async fn saves_relays_to_config() -> Result<()> {
                 let mut m = MockUserManager::default();
                 let mut client = generate_mock_client();
                 m.config_manager
@@ -865,16 +865,16 @@ mod tests {
                     .expect_get_events()
                     .returning(|_, _| Ok(vec![generate_relaylist_event()]));
 
-                futures::executor::block_on(m.get_user(
+                let _ = m.get_user(
                     &client,
                     &TEST_KEY_1_KEYS.public_key(),
                     5 * 60, // 5 mins ago
-                ))?;
+                ).await?;
                 Ok(())
             }
 
-            #[test]
-            fn updates_relays_created_at() -> Result<()> {
+            #[tokio::test]
+            async fn updates_relays_created_at() -> Result<()> {
                 let mut m = MockUserManager::default();
                 let mut client = generate_mock_client();
                 m.config_manager
@@ -889,16 +889,16 @@ mod tests {
                     .expect_get_events()
                     .returning(|_, _| Ok(vec![generate_relaylist_event()]));
 
-                futures::executor::block_on(m.get_user(
+                let _ = m.get_user(
                     &client,
                     &TEST_KEY_1_KEYS.public_key(),
                     5 * 60, // 5 mins ago
-                ))?;
+                ).await?;
                 Ok(())
             }
 
-            #[test]
-            fn when_no_changes_updates_last_updated() -> Result<()> {
+            #[tokio::test]
+            async fn when_no_changes_updates_last_updated() -> Result<()> {
                 let mut m = MockUserManager::default();
                 let mut client = generate_mock_client();
                 m.config_manager
@@ -911,16 +911,16 @@ mod tests {
                     .returning(|_| Ok(()));
                 client.expect_get_events().returning(|_, _| Ok(vec![]));
 
-                futures::executor::block_on(m.get_user(
+                let _ = m.get_user(
                     &client,
                     &TEST_KEY_1_KEYS.public_key(),
                     5 * 60, // 5 mins ago
-                ))?;
+                ).await?;
                 Ok(())
             }
 
-            #[test]
-            fn when_changes_updates_last_updated() -> Result<()> {
+            #[tokio::test]
+            async fn when_changes_updates_last_updated() -> Result<()> {
                 let mut m = MockUserManager::default();
                 let mut client = generate_mock_client();
                 m.config_manager
@@ -935,19 +935,19 @@ mod tests {
                     .expect_get_events()
                     .returning(|_, _| Ok(vec![generate_test_key_1_metadata_event("fred")]));
 
-                futures::executor::block_on(m.get_user(
+                let _ = m.get_user(
                     &client,
                     &TEST_KEY_1_KEYS.public_key(),
                     5 * 60, // 5 mins ago
-                ))?;
+                ).await?;
                 Ok(())
             }
         }
 
         mod fetches_from_correct_relays {
             use super::*;
-            #[test]
-            fn when_userref_write_relays_present_fetches_only_from_them() -> Result<()> {
+            #[tokio::test]
+            async fn when_userref_write_relays_present_fetches_only_from_them() -> Result<()> {
                 let mut m = MockUserManager::default();
                 let mut client = generate_mock_client();
                 m.config_manager
@@ -966,15 +966,16 @@ mod tests {
                     })
                     .returning(|_, _| Ok(vec![]));
 
-                futures::executor::block_on(m.get_user(
+                let _ = m.get_user(
                     &client,
                     &TEST_KEY_1_KEYS.public_key(),
                     5 * 60, // 5 mins ago
-                ))?;
+                ).await?;
                 Ok(())
             }
-            #[test]
-            fn when_userref_write_relays_not_present_fetches_from_fallback_relays() -> Result<()> {
+
+            #[tokio::test]
+            async fn when_userref_write_relays_not_present_fetches_from_fallback_relays() -> Result<()> {
                 let mut m = MockUserManager::default();
                 let mut client = generate_mock_client();
                 m.config_manager.expect_load().returning(|| {
@@ -996,19 +997,19 @@ mod tests {
                     .withf(move |relays, _filters| fallback_relays().eq(relays))
                     .returning(|_, _| Ok(vec![]));
 
-                futures::executor::block_on(m.get_user(
+                let _ = m.get_user(
                     &client,
                     &TEST_KEY_1_KEYS.public_key(),
                     5 * 60, // 5 mins ago
-                ))?;
+                ).await?;
                 Ok(())
             }
 
             mod fetches_from_new_relays_discovered_in_incoming_relay_list {
                 use super::*;
 
-                #[test]
-                fn when_all_relays_in_list_are_new_finds_name() -> Result<()> {
+                #[tokio::test]
+                async fn when_all_relays_in_list_are_new_finds_name() -> Result<()> {
                     let mut m = MockUserManager::default();
                     let mut client = generate_mock_client();
                     m.config_manager.expect_load().returning(|| {
@@ -1052,17 +1053,17 @@ mod tests {
                             }
                         });
 
-                    let res = futures::executor::block_on(m.get_user(
+                    let res = m.get_user(
                         &client,
                         &TEST_KEY_1_KEYS.public_key(),
                         5 * 60, // 5 mins ago
-                    ))?;
+                    ).await?;
                     assert_eq!(res.metadata.name, "fred");
                     Ok(())
                 }
 
-                #[test]
-                fn only_fetches_from_newly_added_relays() -> Result<()> {
+                #[tokio::test]
+                async fn only_fetches_from_newly_added_relays() -> Result<()> {
                     let mut m = MockUserManager::default();
                     let mut client = generate_mock_client();
                     m.config_manager.expect_load().returning(|| {
@@ -1095,19 +1096,19 @@ mod tests {
                             }
                         });
 
-                    let res = futures::executor::block_on(m.get_user(
+                    let res = m.get_user(
                         &client,
                         &TEST_KEY_1_KEYS.public_key(),
                         5 * 60, // 5 mins ago
-                    ))?;
+                    ).await?;
                     assert_eq!(res.metadata.name, "fred");
                     Ok(())
                 }
             }
         }
 
-        #[test]
-        fn when_failed_to_fetch_events_returns_cached_details() -> Result<()> {
+        #[tokio::test]
+        async fn when_failed_to_fetch_events_returns_cached_details() -> Result<()> {
             let mut m = MockUserManager::default();
             let mut client = generate_mock_client();
             m.config_manager
@@ -1117,11 +1118,11 @@ mod tests {
                 .expect_get_events()
                 .returning(|_, _| Err(anyhow!("test error")));
 
-            let res = futures::executor::block_on(m.get_user(
+            let res = m.get_user(
                 &client,
                 &TEST_KEY_1_KEYS.public_key(),
                 5 * 60, // 10 mins ago
-            ))?;
+            ).await?;
             assert_eq!(res.metadata.name, "Fred");
             Ok(())
         }

--- a/src/key_handling/users.rs
+++ b/src/key_handling/users.rs
@@ -680,17 +680,20 @@ mod tests {
             use super::*;
 
             #[tokio::test]
-            async fn returns_cached_details_without_checking_relays_or_updaing_config() -> Result<()> {
+            async fn returns_cached_details_without_checking_relays_or_updaing_config() -> Result<()>
+            {
                 let mut m = MockUserManager::default();
                 let client = generate_mock_client();
                 m.config_manager
                     .expect_load()
                     .returning(|| Ok(generate_standard_config()));
-                let res = m.get_user(
-                    &client,
-                    &TEST_KEY_1_KEYS.public_key(),
-                    24 * 60 * 60, // within 24 hours
-                ).await?;
+                let res = m
+                    .get_user(
+                        &client,
+                        &TEST_KEY_1_KEYS.public_key(),
+                        24 * 60 * 60, // within 24 hours
+                    )
+                    .await?;
                 assert_eq!(res.metadata.name, "Fred");
                 assert_eq!(res.relays.relays[0].url, "ws://existingread");
                 Ok(())
@@ -712,11 +715,13 @@ mod tests {
                     .expect_get_events()
                     .returning(|_, _| Ok(vec![generate_test_key_1_metadata_event("fred")]));
 
-                let res = m.get_user(
-                    &client,
-                    &TEST_KEY_1_KEYS.public_key(),
-                    5 * 60, // 5 mins ago
-                ).await?;
+                let res = m
+                    .get_user(
+                        &client,
+                        &TEST_KEY_1_KEYS.public_key(),
+                        5 * 60, // 5 mins ago
+                    )
+                    .await?;
                 assert_eq!(res.metadata.name, "fred");
                 Ok(())
             }
@@ -736,11 +741,13 @@ mod tests {
                     ])
                 });
 
-                let res = m.get_user(
-                    &client,
-                    &TEST_KEY_1_KEYS.public_key(),
-                    5 * 60, // 5 mins ago
-                ).await?;
+                let res = m
+                    .get_user(
+                        &client,
+                        &TEST_KEY_1_KEYS.public_key(),
+                        5 * 60, // 5 mins ago
+                    )
+                    .await?;
                 assert_eq!(res.metadata.name, "fred");
                 Ok(())
             }
@@ -760,11 +767,13 @@ mod tests {
                     ])
                 });
 
-                let res = m.get_user(
-                    &client,
-                    &TEST_KEY_1_KEYS.public_key(),
-                    5 * 60, // 5 mins ago
-                ).await?;
+                let res = m
+                    .get_user(
+                        &client,
+                        &TEST_KEY_1_KEYS.public_key(),
+                        5 * 60, // 5 mins ago
+                    )
+                    .await?;
                 assert_eq!(res.relays.relays, expected_userrelayrefs(),);
                 Ok(())
             }
@@ -788,11 +797,13 @@ mod tests {
                     ])
                 });
 
-                let res = m.get_user(
-                    &client,
-                    &TEST_KEY_1_KEYS.public_key(),
-                    5 * 60, // 5 mins ago
-                ).await?;
+                let res = m
+                    .get_user(
+                        &client,
+                        &TEST_KEY_1_KEYS.public_key(),
+                        5 * 60, // 5 mins ago
+                    )
+                    .await?;
                 assert_eq!(res.relays.relays, expected_userrelayrefs(),);
                 Ok(())
             }
@@ -817,11 +828,13 @@ mod tests {
                     .expect_get_events()
                     .returning(|_, _| Ok(vec![generate_test_key_1_metadata_event("fred")]));
 
-                let _ = m.get_user(
-                    &client,
-                    &TEST_KEY_1_KEYS.public_key(),
-                    5 * 60, // 5 mins ago
-                ).await?;
+                let _ = m
+                    .get_user(
+                        &client,
+                        &TEST_KEY_1_KEYS.public_key(),
+                        5 * 60, // 5 mins ago
+                    )
+                    .await?;
                 Ok(())
             }
 
@@ -841,11 +854,13 @@ mod tests {
                     .expect_get_events()
                     .returning(|_, _| Ok(vec![generate_test_key_1_metadata_event("fred")]));
 
-                let _ = m.get_user(
-                    &client,
-                    &TEST_KEY_1_KEYS.public_key(),
-                    5 * 60, // 5 mins ago
-                ).await?;
+                let _ = m
+                    .get_user(
+                        &client,
+                        &TEST_KEY_1_KEYS.public_key(),
+                        5 * 60, // 5 mins ago
+                    )
+                    .await?;
                 Ok(())
             }
 
@@ -865,11 +880,13 @@ mod tests {
                     .expect_get_events()
                     .returning(|_, _| Ok(vec![generate_relaylist_event()]));
 
-                let _ = m.get_user(
-                    &client,
-                    &TEST_KEY_1_KEYS.public_key(),
-                    5 * 60, // 5 mins ago
-                ).await?;
+                let _ = m
+                    .get_user(
+                        &client,
+                        &TEST_KEY_1_KEYS.public_key(),
+                        5 * 60, // 5 mins ago
+                    )
+                    .await?;
                 Ok(())
             }
 
@@ -889,11 +906,13 @@ mod tests {
                     .expect_get_events()
                     .returning(|_, _| Ok(vec![generate_relaylist_event()]));
 
-                let _ = m.get_user(
-                    &client,
-                    &TEST_KEY_1_KEYS.public_key(),
-                    5 * 60, // 5 mins ago
-                ).await?;
+                let _ = m
+                    .get_user(
+                        &client,
+                        &TEST_KEY_1_KEYS.public_key(),
+                        5 * 60, // 5 mins ago
+                    )
+                    .await?;
                 Ok(())
             }
 
@@ -911,11 +930,13 @@ mod tests {
                     .returning(|_| Ok(()));
                 client.expect_get_events().returning(|_, _| Ok(vec![]));
 
-                let _ = m.get_user(
-                    &client,
-                    &TEST_KEY_1_KEYS.public_key(),
-                    5 * 60, // 5 mins ago
-                ).await?;
+                let _ = m
+                    .get_user(
+                        &client,
+                        &TEST_KEY_1_KEYS.public_key(),
+                        5 * 60, // 5 mins ago
+                    )
+                    .await?;
                 Ok(())
             }
 
@@ -935,11 +956,13 @@ mod tests {
                     .expect_get_events()
                     .returning(|_, _| Ok(vec![generate_test_key_1_metadata_event("fred")]));
 
-                let _ = m.get_user(
-                    &client,
-                    &TEST_KEY_1_KEYS.public_key(),
-                    5 * 60, // 5 mins ago
-                ).await?;
+                let _ = m
+                    .get_user(
+                        &client,
+                        &TEST_KEY_1_KEYS.public_key(),
+                        5 * 60, // 5 mins ago
+                    )
+                    .await?;
                 Ok(())
             }
         }
@@ -966,16 +989,19 @@ mod tests {
                     })
                     .returning(|_, _| Ok(vec![]));
 
-                let _ = m.get_user(
-                    &client,
-                    &TEST_KEY_1_KEYS.public_key(),
-                    5 * 60, // 5 mins ago
-                ).await?;
+                let _ = m
+                    .get_user(
+                        &client,
+                        &TEST_KEY_1_KEYS.public_key(),
+                        5 * 60, // 5 mins ago
+                    )
+                    .await?;
                 Ok(())
             }
 
             #[tokio::test]
-            async fn when_userref_write_relays_not_present_fetches_from_fallback_relays() -> Result<()> {
+            async fn when_userref_write_relays_not_present_fetches_from_fallback_relays()
+            -> Result<()> {
                 let mut m = MockUserManager::default();
                 let mut client = generate_mock_client();
                 m.config_manager.expect_load().returning(|| {
@@ -997,11 +1023,13 @@ mod tests {
                     .withf(move |relays, _filters| fallback_relays().eq(relays))
                     .returning(|_, _| Ok(vec![]));
 
-                let _ = m.get_user(
-                    &client,
-                    &TEST_KEY_1_KEYS.public_key(),
-                    5 * 60, // 5 mins ago
-                ).await?;
+                let _ = m
+                    .get_user(
+                        &client,
+                        &TEST_KEY_1_KEYS.public_key(),
+                        5 * 60, // 5 mins ago
+                    )
+                    .await?;
                 Ok(())
             }
 
@@ -1053,11 +1081,13 @@ mod tests {
                             }
                         });
 
-                    let res = m.get_user(
-                        &client,
-                        &TEST_KEY_1_KEYS.public_key(),
-                        5 * 60, // 5 mins ago
-                    ).await?;
+                    let res = m
+                        .get_user(
+                            &client,
+                            &TEST_KEY_1_KEYS.public_key(),
+                            5 * 60, // 5 mins ago
+                        )
+                        .await?;
                     assert_eq!(res.metadata.name, "fred");
                     Ok(())
                 }
@@ -1096,11 +1126,13 @@ mod tests {
                             }
                         });
 
-                    let res = m.get_user(
-                        &client,
-                        &TEST_KEY_1_KEYS.public_key(),
-                        5 * 60, // 5 mins ago
-                    ).await?;
+                    let res = m
+                        .get_user(
+                            &client,
+                            &TEST_KEY_1_KEYS.public_key(),
+                            5 * 60, // 5 mins ago
+                        )
+                        .await?;
                     assert_eq!(res.metadata.name, "fred");
                     Ok(())
                 }
@@ -1118,11 +1150,13 @@ mod tests {
                 .expect_get_events()
                 .returning(|_, _| Err(anyhow!("test error")));
 
-            let res = m.get_user(
-                &client,
-                &TEST_KEY_1_KEYS.public_key(),
-                5 * 60, // 10 mins ago
-            ).await?;
+            let res = m
+                .get_user(
+                    &client,
+                    &TEST_KEY_1_KEYS.public_key(),
+                    5 * 60, // 10 mins ago
+                )
+                .await?;
             assert_eq!(res.metadata.name, "Fred");
             Ok(())
         }

--- a/tests/claim.rs
+++ b/tests/claim.rs
@@ -114,10 +114,10 @@ mod when_repo_not_previously_claimed {
         mod sent_to_correct_relays {
             use super::*;
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn only_1_repository_kind_event_sent_to_user_relays() -> Result<()> {
-                let (_, _, r53, r55, _) = futures::executor::block_on(prep_run_claim())?;
+            async fn only_1_repository_kind_event_sent_to_user_relays() -> Result<()> {
+                let (_, _, r53, r55, _) = prep_run_claim().await?;
                 for relay in [&r53, &r55] {
                     assert_eq!(
                         relay
@@ -131,10 +131,10 @@ mod when_repo_not_previously_claimed {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn only_1_repository_kind_event_sent_to_specified_repo_relays() -> Result<()> {
-                let (_, _, _, r55, r56) = futures::executor::block_on(prep_run_claim())?;
+            async fn only_1_repository_kind_event_sent_to_specified_repo_relays() -> Result<()> {
+                let (_, _, _, r55, r56) = prep_run_claim().await?;
                 for relay in [&r55, &r56] {
                     assert_eq!(
                         relay
@@ -148,10 +148,10 @@ mod when_repo_not_previously_claimed {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn event_not_sent_to_fallback_relay() -> Result<()> {
-                let (r51, r52, _, _, _) = futures::executor::block_on(prep_run_claim())?;
+            async fn event_not_sent_to_fallback_relay() -> Result<()> {
+                let (r51, r52, _, _, _) = prep_run_claim().await?;
                 for relay in [&r51, &r52] {
                     assert_eq!(
                         relay
@@ -238,10 +238,10 @@ mod when_repo_not_previously_claimed {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn contains_maintainers_and_relays() -> Result<()> {
-                futures::executor::block_on(async_run_test())?;
+            async fn contains_maintainers_and_relays() -> Result<()> {
+                async_run_test().await?;
                 Ok(())
             }
         }
@@ -249,10 +249,10 @@ mod when_repo_not_previously_claimed {
         mod tags {
             use super::*;
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn root_commit_as_d_replaceable_event_identifier() -> Result<()> {
-                let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_claim())?;
+            async fn root_commit_as_d_replaceable_event_identifier() -> Result<()> {
+                let (_, _, r53, r55, r56) = prep_run_claim().await?;
                 for relay in [&r53, &r55, &r56] {
                     let event: &nostr::Event = relay
                         .events
@@ -266,10 +266,10 @@ mod when_repo_not_previously_claimed {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn root_commit_as_reference() -> Result<()> {
-                let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_claim())?;
+            async fn root_commit_as_reference() -> Result<()> {
+                let (_, _, r53, r55, r56) = prep_run_claim().await?;
                 for relay in [&r53, &r55, &r56] {
                     let event: &nostr::Event = relay
                         .events
@@ -284,10 +284,10 @@ mod when_repo_not_previously_claimed {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn name() -> Result<()> {
-                let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_claim())?;
+            async fn name() -> Result<()> {
+                let (_, _, r53, r55, r56) = prep_run_claim().await?;
                 for relay in [&r53, &r55, &r56] {
                     let event: &nostr::Event = relay
                         .events
@@ -305,10 +305,10 @@ mod when_repo_not_previously_claimed {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn description() -> Result<()> {
-                let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_claim())?;
+            async fn description() -> Result<()> {
+                let (_, _, r53, r55, r56) = prep_run_claim().await?;
                 for relay in [&r53, &r55, &r56] {
                     let event: &nostr::Event = relay
                         .events
@@ -322,10 +322,10 @@ mod when_repo_not_previously_claimed {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn git_server() -> Result<()> {
-                let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_claim())?;
+            async fn git_server() -> Result<()> {
+                let (_, _, r53, r55, r56) = prep_run_claim().await?;
                 for relay in [&r53, &r55, &r56] {
                     let event: &nostr::Event = relay
                         .events
@@ -339,10 +339,10 @@ mod when_repo_not_previously_claimed {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn git_server_as_reference() -> Result<()> {
-                let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_claim())?;
+            async fn git_server_as_reference() -> Result<()> {
+                let (_, _, r53, r55, r56) = prep_run_claim().await?;
                 for relay in [&r53, &r55, &r56] {
                     let event: &nostr::Event = relay
                         .events
@@ -357,10 +357,10 @@ mod when_repo_not_previously_claimed {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn relays() -> Result<()> {
-                let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_claim())?;
+            async fn relays() -> Result<()> {
+                let (_, _, r53, r55, r56) = prep_run_claim().await?;
                 for relay in [&r53, &r55, &r56] {
                     let event: &nostr::Event = relay
                         .events
@@ -379,10 +379,10 @@ mod when_repo_not_previously_claimed {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn current_user_tagged_indicating_maintainer() -> Result<()> {
-                let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_claim())?;
+            async fn current_user_tagged_indicating_maintainer() -> Result<()> {
+                let (_, _, r53, r55, r56) = prep_run_claim().await?;
                 for relay in [&r53, &r55, &r56] {
                     let event: &nostr::Event = relay
                         .events
@@ -465,10 +465,10 @@ mod when_repo_not_previously_claimed {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn check_cli_output() -> Result<()> {
-                futures::executor::block_on(run_test_async())?;
+            async fn check_cli_output() -> Result<()> {
+                run_test_async().await?;
                 Ok(())
             }
         }
@@ -561,10 +561,10 @@ mod when_repo_not_previously_claimed {
         mod tags {
             use super::*;
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn relays_match_user_write_relays() -> Result<()> {
-                let (_, _, r53, r55, _) = futures::executor::block_on(prep_run_claim())?;
+            async fn relays_match_user_write_relays() -> Result<()> {
+                let (_, _, r53, r55, _) = prep_run_claim().await?;
                 for relay in [&r53, &r55] {
                     let event: &nostr::Event = relay
                         .events
@@ -643,10 +643,10 @@ mod when_repo_not_previously_claimed {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn check_cli_output() -> Result<()> {
-                futures::executor::block_on(run_test_async())?;
+            async fn check_cli_output() -> Result<()> {
+                run_test_async().await?;
                 Ok(())
             }
         }

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -121,10 +121,10 @@ mod with_relays {
                     Ok(())
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn when_latest_metadata_and_relay_list_on_all_relays() -> Result<()> {
-                    futures::executor::block_on(run_test_displays_correct_name(
+                async fn when_latest_metadata_and_relay_list_on_all_relays() -> Result<()> {
+                    run_test_displays_correct_name(
                         Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                             relay.respond_events(
                                 client_id,
@@ -147,16 +147,16 @@ mod with_relays {
                             )?;
                             Ok(())
                         }),
-                    ))
+                    ).await
                 }
 
                 mod poorly_quality_metadata_event {
                     use super::*;
 
-                    #[test]
+                    #[tokio::test]
                     #[serial]
-                    fn when_metadata_contains_only_display_name() -> Result<()> {
-                        futures::executor::block_on(run_test_displays_correct_name(
+                    async fn when_metadata_contains_only_display_name() -> Result<()> {
+                        run_test_displays_correct_name(
                             Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                                 relay.respond_events(
                                     client_id,
@@ -173,12 +173,12 @@ mod with_relays {
                                 Ok(())
                             }),
                             None,
-                        ))
+                        ).await
                     }
 
-                    #[test]
+                    #[tokio::test]
                     #[serial]
-                    fn when_metadata_contains_only_displayname() -> Result<()> {
+                    async fn when_metadata_contains_only_displayname() -> Result<()> {
                         println!(
                             "displayName: {}",
                             nostr::Metadata::new()
@@ -192,7 +192,7 @@ mod with_relays {
                             nostr::Metadata::new().name("fred").name.unwrap()
                         );
 
-                        futures::executor::block_on(run_test_displays_correct_name(
+                        run_test_displays_correct_name(
                             Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                                 relay.respond_events(
                                     client_id,
@@ -210,12 +210,12 @@ mod with_relays {
                                 Ok(())
                             }),
                             None,
-                        ))
+                        ).await
                     }
 
-                    #[test]
+                    #[tokio::test]
                     #[serial]
-                    fn displays_npub_when_metadata_contains_no_name_displayname_or_display_name()
+                    async fn displays_npub_when_metadata_contains_no_name_displayname_or_display_name()
                     -> Result<()> {
                         println!(
                             "displayName: {}",
@@ -230,7 +230,7 @@ mod with_relays {
                             nostr::Metadata::new().name("fred").name.unwrap()
                         );
 
-                        futures::executor::block_on(run_test_displays_fallback_to_npub(
+                        run_test_displays_fallback_to_npub(
                             Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                                 relay.respond_events(
                                     client_id,
@@ -247,15 +247,15 @@ mod with_relays {
                                 Ok(())
                             }),
                             None,
-                        ))
+                        ).await
                     }
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn when_latest_metadata_and_relay_list_on_some_relays_but_others_have_none()
+                async fn when_latest_metadata_and_relay_list_on_some_relays_but_others_have_none()
                 -> Result<()> {
-                    futures::executor::block_on(run_test_displays_correct_name(
+                    run_test_displays_correct_name(
                         Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                             relay.respond_events(
                                 client_id,
@@ -268,13 +268,13 @@ mod with_relays {
                             Ok(())
                         }),
                         None,
-                    ))
+                    ).await
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn when_latest_metadata_only_on_relay_and_relay_list_on_another() -> Result<()> {
-                    futures::executor::block_on(run_test_displays_correct_name(
+                async fn when_latest_metadata_only_on_relay_and_relay_list_on_another() -> Result<()> {
+                    run_test_displays_correct_name(
                         Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                             relay.respond_events(
                                 client_id,
@@ -291,13 +291,13 @@ mod with_relays {
                             )?;
                             Ok(())
                         }),
-                    ))
+                    ).await
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn when_some_relays_return_old_metadata_event() -> Result<()> {
-                    futures::executor::block_on(run_test_displays_correct_name(
+                async fn when_some_relays_return_old_metadata_event() -> Result<()> {
+                    run_test_displays_correct_name(
                         Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                             relay.respond_events(
                                 client_id,
@@ -317,13 +317,13 @@ mod with_relays {
                             )?;
                             Ok(())
                         }),
-                    ))
+                    ).await
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn when_some_relays_return_other_users_metadata() -> Result<()> {
-                    futures::executor::block_on(run_test_displays_correct_name(
+                async fn when_some_relays_return_other_users_metadata() -> Result<()> {
+                    run_test_displays_correct_name(
                         Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                             relay.respond_events(
                                 client_id,
@@ -343,13 +343,13 @@ mod with_relays {
                             )?;
                             Ok(())
                         }),
-                    ))
+                    ).await
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn when_some_relays_return_other_event_kinds() -> Result<()> {
-                    futures::executor::block_on(run_test_displays_correct_name(
+                async fn when_some_relays_return_other_event_kinds() -> Result<()> {
+                    run_test_displays_correct_name(
                         Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                             let event = generate_test_key_1_kind_event(nostr::Kind::TextNote);
                             relay.respond_events(
@@ -370,16 +370,16 @@ mod with_relays {
                             )?;
                             Ok(())
                         }),
-                    ))
+                    ).await
                 }
 
                 mod when_specifying_command_line_nsec_only {
                     use super::*;
 
-                    #[test]
+                    #[tokio::test]
                     #[serial]
-                    fn displays_correct_name() -> Result<()> {
-                        futures::executor::block_on(
+                    async fn displays_correct_name() -> Result<()> {
+                        
                             run_test_when_specifying_command_line_nsec_only_displays_correct_name(
                                 Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                                     relay.respond_events(
@@ -393,8 +393,8 @@ mod with_relays {
                                     Ok(())
                                 }),
                                 None,
-                            ),
-                        )
+                            ).await
+                
                     }
                     async fn run_test_when_specifying_command_line_nsec_only_displays_correct_name(
                         relay_listener1: Option<ListenerReqFunc<'_>>,
@@ -430,10 +430,10 @@ mod with_relays {
                 mod when_specifying_command_line_password_only {
                     use super::*;
 
-                    #[test]
+                    #[tokio::test]
                     #[serial]
-                    fn displays_correct_name() -> Result<()> {
-                        futures::executor::block_on(
+                    async fn displays_correct_name() -> Result<()> {
+                        
                         run_test_when_specifying_command_line_password_only_displays_correct_name(
                             Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                                 relay.respond_events(
@@ -447,8 +447,8 @@ mod with_relays {
                                 Ok(())
                             }),
                             None,
-                        ),
-                    )
+                        ).await
+                    
                     }
                     async fn run_test_when_specifying_command_line_password_only_displays_correct_name(
                         relay_listener1: Option<ListenerReqFunc<'_>>,
@@ -495,10 +495,10 @@ mod with_relays {
                 mod when_specifying_command_line_nsec_and_password {
                     use super::*;
 
-                    #[test]
+                    #[tokio::test]
                     #[serial]
-                    fn displays_correct_name() -> Result<()> {
-                        futures::executor::block_on(
+                    async fn displays_correct_name() -> Result<()> {
+                        
                         run_test_when_specifying_command_line_nsec_and_password_displays_correct_name(
                             Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                                 relay.respond_events(
@@ -512,8 +512,7 @@ mod with_relays {
                                 Ok(())
                             }),
                             None,
-                        ),
-                    )
+                        ).await
                     }
                     async fn run_test_when_specifying_command_line_nsec_and_password_displays_correct_name(
                         relay_listener1: Option<ListenerReqFunc<'_>>,
@@ -557,12 +556,11 @@ mod with_relays {
             mod when_no_metadata_found {
                 use super::*;
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn warm_user_and_displays_npub() -> Result<()> {
-                    futures::executor::block_on(
-                        run_test_when_no_metadata_found_warns_user_and_uses_npub(None, None),
-                    )
+                async fn warm_user_and_displays_npub() -> Result<()> {
+                        run_test_when_no_metadata_found_warns_user_and_uses_npub(None, None).await
+                    
                 }
 
                 async fn run_test_when_no_metadata_found_warns_user_and_uses_npub(
@@ -612,10 +610,9 @@ mod with_relays {
             mod when_metadata_but_no_relay_list_found {
                 use super::*;
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn warm_user_and_displays_name() -> Result<()> {
-                    futures::executor::block_on(
+                async fn warm_user_and_displays_name() -> Result<()> {
                         run_test_when_no_relay_list_found_warns_user_and_uses_npub(
                             Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                                 relay.respond_events(
@@ -626,8 +623,7 @@ mod with_relays {
                                 Ok(())
                             }),
                             None,
-                        ),
-                    )
+                        ).await
                 }
 
                 async fn run_test_when_no_relay_list_found_warns_user_and_uses_npub(
@@ -682,10 +678,10 @@ mod with_relays {
             mod uses_cache {
                 use super::*;
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn dislays_logged_in_with_correct_name() -> Result<()> {
-                    futures::executor::block_on(run_test_dislays_logged_in_with_correct_name(Some(
+                async fn dislays_logged_in_with_correct_name() -> Result<()> {
+                    run_test_dislays_logged_in_with_correct_name(Some(
                         &|relay, client_id, subscription_id, _| -> Result<()> {
                             relay.respond_events(
                                 client_id,
@@ -697,7 +693,7 @@ mod with_relays {
                             )?;
                             Ok(())
                         },
-                    )))
+                    )).await
                 }
                 async fn run_test_dislays_logged_in_with_correct_name(
                     relay_listener: Option<ListenerReqFunc<'_>>,
@@ -794,10 +790,10 @@ mod with_relays {
             }
 
             /// this also tests that additional relays are queried
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn displays_correct_name() -> Result<()> {
-                futures::executor::block_on(run_test_displays_correct_name(
+            async fn displays_correct_name() -> Result<()> {
+                run_test_displays_correct_name(
                     Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                         relay.respond_events(
                             client_id,
@@ -820,7 +816,7 @@ mod with_relays {
                         )?;
                         Ok(())
                     }),
-                ))
+                ).await
             }
         }
     }

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -147,7 +147,8 @@ mod with_relays {
                             )?;
                             Ok(())
                         }),
-                    ).await
+                    )
+                    .await
                 }
 
                 mod poorly_quality_metadata_event {
@@ -173,7 +174,8 @@ mod with_relays {
                                 Ok(())
                             }),
                             None,
-                        ).await
+                        )
+                        .await
                     }
 
                     #[tokio::test]
@@ -210,7 +212,8 @@ mod with_relays {
                                 Ok(())
                             }),
                             None,
-                        ).await
+                        )
+                        .await
                     }
 
                     #[tokio::test]
@@ -247,7 +250,8 @@ mod with_relays {
                                 Ok(())
                             }),
                             None,
-                        ).await
+                        )
+                        .await
                     }
                 }
 
@@ -268,12 +272,14 @@ mod with_relays {
                             Ok(())
                         }),
                         None,
-                    ).await
+                    )
+                    .await
                 }
 
                 #[tokio::test]
                 #[serial]
-                async fn when_latest_metadata_only_on_relay_and_relay_list_on_another() -> Result<()> {
+                async fn when_latest_metadata_only_on_relay_and_relay_list_on_another() -> Result<()>
+                {
                     run_test_displays_correct_name(
                         Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                             relay.respond_events(
@@ -291,7 +297,8 @@ mod with_relays {
                             )?;
                             Ok(())
                         }),
-                    ).await
+                    )
+                    .await
                 }
 
                 #[tokio::test]
@@ -317,7 +324,8 @@ mod with_relays {
                             )?;
                             Ok(())
                         }),
-                    ).await
+                    )
+                    .await
                 }
 
                 #[tokio::test]
@@ -343,7 +351,8 @@ mod with_relays {
                             )?;
                             Ok(())
                         }),
-                    ).await
+                    )
+                    .await
                 }
 
                 #[tokio::test]
@@ -370,7 +379,8 @@ mod with_relays {
                             )?;
                             Ok(())
                         }),
-                    ).await
+                    )
+                    .await
                 }
 
                 mod when_specifying_command_line_nsec_only {
@@ -379,22 +389,21 @@ mod with_relays {
                     #[tokio::test]
                     #[serial]
                     async fn displays_correct_name() -> Result<()> {
-                        
-                            run_test_when_specifying_command_line_nsec_only_displays_correct_name(
-                                Some(&|relay, client_id, subscription_id, _| -> Result<()> {
-                                    relay.respond_events(
-                                        client_id,
-                                        &subscription_id,
-                                        &vec![
-                                            generate_test_key_1_metadata_event("fred"),
-                                            generate_test_key_1_relay_list_event_same_as_fallback(),
-                                        ],
-                                    )?;
-                                    Ok(())
-                                }),
-                                None,
-                            ).await
-                
+                        run_test_when_specifying_command_line_nsec_only_displays_correct_name(
+                            Some(&|relay, client_id, subscription_id, _| -> Result<()> {
+                                relay.respond_events(
+                                    client_id,
+                                    &subscription_id,
+                                    &vec![
+                                        generate_test_key_1_metadata_event("fred"),
+                                        generate_test_key_1_relay_list_event_same_as_fallback(),
+                                    ],
+                                )?;
+                                Ok(())
+                            }),
+                            None,
+                        )
+                        .await
                     }
                     async fn run_test_when_specifying_command_line_nsec_only_displays_correct_name(
                         relay_listener1: Option<ListenerReqFunc<'_>>,
@@ -433,7 +442,6 @@ mod with_relays {
                     #[tokio::test]
                     #[serial]
                     async fn displays_correct_name() -> Result<()> {
-                        
                         run_test_when_specifying_command_line_password_only_displays_correct_name(
                             Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                                 relay.respond_events(
@@ -447,8 +455,8 @@ mod with_relays {
                                 Ok(())
                             }),
                             None,
-                        ).await
-                    
+                        )
+                        .await
                     }
                     async fn run_test_when_specifying_command_line_password_only_displays_correct_name(
                         relay_listener1: Option<ListenerReqFunc<'_>>,
@@ -498,7 +506,6 @@ mod with_relays {
                     #[tokio::test]
                     #[serial]
                     async fn displays_correct_name() -> Result<()> {
-                        
                         run_test_when_specifying_command_line_nsec_and_password_displays_correct_name(
                             Some(&|relay, client_id, subscription_id, _| -> Result<()> {
                                 relay.respond_events(
@@ -559,8 +566,7 @@ mod with_relays {
                 #[tokio::test]
                 #[serial]
                 async fn warm_user_and_displays_npub() -> Result<()> {
-                        run_test_when_no_metadata_found_warns_user_and_uses_npub(None, None).await
-                    
+                    run_test_when_no_metadata_found_warns_user_and_uses_npub(None, None).await
                 }
 
                 async fn run_test_when_no_metadata_found_warns_user_and_uses_npub(
@@ -613,17 +619,18 @@ mod with_relays {
                 #[tokio::test]
                 #[serial]
                 async fn warm_user_and_displays_name() -> Result<()> {
-                        run_test_when_no_relay_list_found_warns_user_and_uses_npub(
-                            Some(&|relay, client_id, subscription_id, _| -> Result<()> {
-                                relay.respond_events(
-                                    client_id,
-                                    &subscription_id,
-                                    &vec![generate_test_key_1_metadata_event("fred")],
-                                )?;
-                                Ok(())
-                            }),
-                            None,
-                        ).await
+                    run_test_when_no_relay_list_found_warns_user_and_uses_npub(
+                        Some(&|relay, client_id, subscription_id, _| -> Result<()> {
+                            relay.respond_events(
+                                client_id,
+                                &subscription_id,
+                                &vec![generate_test_key_1_metadata_event("fred")],
+                            )?;
+                            Ok(())
+                        }),
+                        None,
+                    )
+                    .await
                 }
 
                 async fn run_test_when_no_relay_list_found_warns_user_and_uses_npub(
@@ -693,7 +700,8 @@ mod with_relays {
                             )?;
                             Ok(())
                         },
-                    )).await
+                    ))
+                    .await
                 }
                 async fn run_test_dislays_logged_in_with_correct_name(
                     relay_listener: Option<ListenerReqFunc<'_>>,
@@ -816,7 +824,8 @@ mod with_relays {
                         )?;
                         Ok(())
                     }),
-                ).await
+                )
+                .await
             }
         }
     }

--- a/tests/prs_create.rs
+++ b/tests/prs_create.rs
@@ -252,10 +252,10 @@ mod sends_pr_and_2_patches_to_3_relays {
         Ok((r51, r52, r53, r55, r56))
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn only_1_pr_kind_event_sent_to_each_relay() -> Result<()> {
-        let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_create_pr())?;
+    async fn only_1_pr_kind_event_sent_to_each_relay() -> Result<()> {
+        let (_, _, r53, r55, r56) = prep_run_create_pr().await?;
         for relay in [&r53, &r55, &r56] {
             assert_eq!(
                 relay
@@ -269,10 +269,10 @@ mod sends_pr_and_2_patches_to_3_relays {
         Ok(())
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn only_1_pr_kind_event_sent_to_user_relays() -> Result<()> {
-        let (_, _, r53, r55, _) = futures::executor::block_on(prep_run_create_pr())?;
+    async fn only_1_pr_kind_event_sent_to_user_relays() -> Result<()> {
+        let (_, _, r53, r55, _) = prep_run_create_pr().await?;
         for relay in [&r53, &r55] {
             assert_eq!(
                 relay
@@ -286,10 +286,10 @@ mod sends_pr_and_2_patches_to_3_relays {
         Ok(())
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn only_1_pr_kind_event_sent_to_repo_relays() -> Result<()> {
-        let (_, _, _, r55, r56) = futures::executor::block_on(prep_run_create_pr())?;
+    async fn only_1_pr_kind_event_sent_to_repo_relays() -> Result<()> {
+        let (_, _, _, r55, r56) = prep_run_create_pr().await?;
         for relay in [&r55, &r56] {
             assert_eq!(
                 relay
@@ -303,10 +303,10 @@ mod sends_pr_and_2_patches_to_3_relays {
         Ok(())
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn pr_not_sent_to_fallback_relay() -> Result<()> {
-        let (r51, r52, _, _, _) = futures::executor::block_on(prep_run_create_pr())?;
+    async fn pr_not_sent_to_fallback_relay() -> Result<()> {
+        let (r51, r52, _, _, _) = prep_run_create_pr().await?;
         for relay in [&r51, &r52] {
             assert_eq!(
                 relay
@@ -320,10 +320,10 @@ mod sends_pr_and_2_patches_to_3_relays {
         Ok(())
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn only_2_patch_kind_events_sent_to_each_relay() -> Result<()> {
-        let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_create_pr())?;
+    async fn only_2_patch_kind_events_sent_to_each_relay() -> Result<()> {
+        let (_, _, r53, r55, r56) = prep_run_create_pr().await?;
         for relay in [&r53, &r55, &r56] {
             assert_eq!(
                 relay
@@ -337,10 +337,10 @@ mod sends_pr_and_2_patches_to_3_relays {
         Ok(())
     }
 
-    #[test]
+    #[tokio::test]
     #[serial]
-    fn patch_content_contains_patch_in_email_format() -> Result<()> {
-        let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_create_pr())?;
+    async fn patch_content_contains_patch_in_email_format() -> Result<()> {
+        let (_, _, r53, r55, r56) = prep_run_create_pr().await?;
         for relay in [&r53, &r55, &r56] {
             let patch_events: Vec<&nostr::Event> = relay
                 .events
@@ -407,10 +407,10 @@ mod sends_pr_and_2_patches_to_3_relays {
     mod pr_tags {
         use super::*;
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn pr_tags_repo_commit() -> Result<()> {
-            let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_create_pr())?;
+        async fn pr_tags_repo_commit() -> Result<()> {
+            let (_, _, r53, r55, r56) = prep_run_create_pr().await?;
             let root_commit = GitTestRepo::default().initial_commit()?;
 
             for relay in [&r53, &r55, &r56] {
@@ -429,10 +429,10 @@ mod sends_pr_and_2_patches_to_3_relays {
             Ok(())
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn pr_tags_title_as_name() -> Result<()> {
-            let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_create_pr())?;
+        async fn pr_tags_title_as_name() -> Result<()> {
+            let (_, _, r53, r55, r56) = prep_run_create_pr().await?;
             for relay in [&r53, &r55, &r56] {
                 let pr_event: &nostr::Event = relay
                     .events
@@ -453,10 +453,10 @@ mod sends_pr_and_2_patches_to_3_relays {
             Ok(())
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn pr_tags_description() -> Result<()> {
-            let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_create_pr())?;
+        async fn pr_tags_description() -> Result<()> {
+            let (_, _, r53, r55, r56) = prep_run_create_pr().await?;
             for relay in [&r53, &r55, &r56] {
                 let pr_event: &nostr::Event = relay
                     .events
@@ -477,10 +477,10 @@ mod sends_pr_and_2_patches_to_3_relays {
             Ok(())
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn pr_tags_branch_name() -> Result<()> {
-            let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_create_pr())?;
+        async fn pr_tags_branch_name() -> Result<()> {
+            let (_, _, r53, r55, r56) = prep_run_create_pr().await?;
             for relay in [&r53, &r55, &r56] {
                 let pr_event: &nostr::Event = relay
                     .events
@@ -506,8 +506,8 @@ mod sends_pr_and_2_patches_to_3_relays {
     mod patch_tags {
         use super::*;
 
-        fn prep() -> Result<nostr::Event> {
-            let (_, _, r53, _, _) = futures::executor::block_on(prep_run_create_pr())?;
+        async fn prep() -> Result<nostr::Event> {
+            let (_, _, r53, _, _) = prep_run_create_pr().await?;
             Ok(r53
                 .events
                 .iter()
@@ -516,11 +516,11 @@ mod sends_pr_and_2_patches_to_3_relays {
                 .clone())
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn commit_and_commit_r() -> Result<()> {
+        async fn commit_and_commit_r() -> Result<()> {
             static COMMIT_ID: &str = "fe973a840fba2a8ab37dd505c154854a69a6505c";
-            let most_recent_patch = prep()?;
+            let most_recent_patch = prep().await?;
             assert!(
                 most_recent_patch
                     .tags
@@ -536,12 +536,12 @@ mod sends_pr_and_2_patches_to_3_relays {
             Ok(())
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn parent_commit_and_parent_commit_r() -> Result<()> {
+        async fn parent_commit_and_parent_commit_r() -> Result<()> {
             // commit parent 'r' and 'parent-commit' tag
             static COMMIT_PARENT_ID: &str = "232efb37ebc67692c9e9ff58b83c0d3d63971a0a";
-            let most_recent_patch = prep()?;
+            let most_recent_patch = prep().await?;
             assert!(
                 most_recent_patch
                     .tags
@@ -556,19 +556,20 @@ mod sends_pr_and_2_patches_to_3_relays {
             Ok(())
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn root_commit_as_r_with_r_hypen_prefix() -> Result<()> {
-            assert!(prep()?.tags.iter().any(|t| t.as_vec()[0].eq("r")
+        async fn root_commit_as_r_with_r_hypen_prefix() -> Result<()> {
+            assert!(prep().await?.tags.iter().any(|t| t.as_vec()[0].eq("r")
                 && t.as_vec()[1].eq("r-9ee507fc4357d7ee16a5d8901bedcd103f23c17d")));
             Ok(())
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn description_with_commit_message() -> Result<()> {
+        async fn description_with_commit_message() -> Result<()> {
             assert_eq!(
-                prep()?
+                prep()
+                    .await?
                     .tags
                     .iter()
                     .find(|t| t.as_vec()[0].eq("description"))
@@ -579,11 +580,12 @@ mod sends_pr_and_2_patches_to_3_relays {
             Ok(())
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn commit_author() -> Result<()> {
+        async fn commit_author() -> Result<()> {
             assert_eq!(
-                prep()?
+                prep()
+                    .await?
                     .tags
                     .iter()
                     .find(|t| t.as_vec()[0].eq("author"))
@@ -594,11 +596,12 @@ mod sends_pr_and_2_patches_to_3_relays {
             Ok(())
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn commit_committer() -> Result<()> {
+        async fn commit_committer() -> Result<()> {
             assert_eq!(
-                prep()?
+                prep()
+                    .await?
                     .tags
                     .iter()
                     .find(|t| t.as_vec()[0].eq("committer"))
@@ -609,10 +612,10 @@ mod sends_pr_and_2_patches_to_3_relays {
             Ok(())
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn patch_tags_pr_event_as_root() -> Result<()> {
-            let (_, _, r53, r55, r56) = futures::executor::block_on(prep_run_create_pr())?;
+        async fn patch_tags_pr_event_as_root() -> Result<()> {
+            let (_, _, r53, r55, r56) = prep_run_create_pr().await?;
             for relay in [&r53, &r55, &r56] {
                 let patch_events: Vec<&nostr::Event> = relay
                     .events
@@ -711,10 +714,10 @@ mod sends_pr_and_2_patches_to_3_relays {
             Ok(())
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn check_cli_output() -> Result<()> {
-            futures::executor::block_on(run_test_async())?;
+        async fn check_cli_output() -> Result<()> {
+            run_test_async().await?;
             Ok(())
         }
     }
@@ -793,10 +796,10 @@ mod sends_pr_and_2_patches_to_3_relays {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn only_first_rejected_event_sent_to_relay() -> Result<()> {
-                futures::executor::block_on(run_test_async())?;
+            async fn only_first_rejected_event_sent_to_relay() -> Result<()> {
+                run_test_async().await?;
                 Ok(())
             }
         }
@@ -885,10 +888,10 @@ mod sends_pr_and_2_patches_to_3_relays {
                 Ok((r51, r52, r53))
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn cli_show_rejection_with_comment() -> Result<()> {
-                futures::executor::block_on(run_test_async())?;
+            async fn cli_show_rejection_with_comment() -> Result<()> {
+                run_test_async().await?;
                 Ok(())
             }
         }

--- a/tests/prs_list.rs
+++ b/tests/prs_list.rs
@@ -226,17 +226,18 @@ mod when_main_branch_is_uptodate {
                         Ok(())
                     }
 
-                    #[test]
+                    #[tokio::test]
                     #[serial]
-                    fn prompts_to_choose_from_pr_titles() -> Result<()> {
-                        futures::executor::block_on(run_async_prompts_to_choose_from_pr_titles())
+                    async fn prompts_to_choose_from_pr_titles() -> Result<()> {
+                        let _ = run_async_prompts_to_choose_from_pr_titles().await;
+                        Ok(())
                     }
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn pr_branch_created_with_correct_name() -> Result<()> {
-                    let (_, test_repo) = futures::executor::block_on(prep_and_run())?;
+                async fn pr_branch_created_with_correct_name() -> Result<()> {
+                    let (_, test_repo) = prep_and_run().await?;
                     assert_eq!(
                         vec![FEATURE_BRANCH_NAME_1, "main"],
                         test_repo.get_local_branch_names()?
@@ -244,10 +245,10 @@ mod when_main_branch_is_uptodate {
                     Ok(())
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn pr_branch_checked_out() -> Result<()> {
-                    let (_, test_repo) = futures::executor::block_on(prep_and_run())?;
+                async fn pr_branch_checked_out() -> Result<()> {
+                    let (_, test_repo) = prep_and_run().await?;
                     assert_eq!(
                         FEATURE_BRANCH_NAME_1,
                         test_repo.get_checked_out_branch_name()?,
@@ -390,17 +391,18 @@ mod when_main_branch_is_uptodate {
                         Ok(())
                     }
 
-                    #[test]
+                    #[tokio::test]
                     #[serial]
-                    fn prompts_to_choose_from_pr_titles() -> Result<()> {
-                        futures::executor::block_on(run_async_prompts_to_choose_from_pr_titles())
+                    async fn prompts_to_choose_from_pr_titles() -> Result<()> {
+                        let _ = run_async_prompts_to_choose_from_pr_titles().await;
+                        Ok(())
                     }
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn pr_branch_created_with_correct_name() -> Result<()> {
-                    let (_, test_repo) = futures::executor::block_on(prep_and_run())?;
+                async fn pr_branch_created_with_correct_name() -> Result<()> {
+                    let (_, test_repo) = prep_and_run().await?;
                     assert_eq!(
                         vec![FEATURE_BRANCH_NAME_3, "main"],
                         test_repo.get_local_branch_names()?
@@ -408,10 +410,10 @@ mod when_main_branch_is_uptodate {
                     Ok(())
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn pr_branch_checked_out() -> Result<()> {
-                    let (_, test_repo) = futures::executor::block_on(prep_and_run())?;
+                async fn pr_branch_checked_out() -> Result<()> {
+                    let (_, test_repo) = prep_and_run().await?;
                     assert_eq!(
                         FEATURE_BRANCH_NAME_3,
                         test_repo.get_checked_out_branch_name()?,
@@ -577,17 +579,18 @@ mod when_main_branch_is_uptodate {
                         Ok(())
                     }
 
-                    #[test]
+                    #[tokio::test]
                     #[serial]
-                    fn prompts_to_choose_from_pr_titles() -> Result<()> {
-                        futures::executor::block_on(run_async_prompts_to_choose_from_pr_titles())
+                    async fn prompts_to_choose_from_pr_titles() -> Result<()> {
+                        let _ = run_async_prompts_to_choose_from_pr_titles().await;
+                        Ok(())
                     }
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn pr_branch_checked_out() -> Result<()> {
-                    let (_, test_repo) = futures::executor::block_on(prep_and_run())?;
+                async fn pr_branch_checked_out() -> Result<()> {
+                    let (_, test_repo) = prep_and_run().await?;
                     assert_eq!(
                         FEATURE_BRANCH_NAME_1,
                         test_repo.get_checked_out_branch_name()?,
@@ -736,17 +739,18 @@ mod when_main_branch_is_uptodate {
                         Ok(())
                     }
 
-                    #[test]
+                    #[tokio::test]
                     #[serial]
-                    fn prompts_to_choose_from_pr_titles() -> Result<()> {
-                        futures::executor::block_on(run_async_prompts_to_choose_from_pr_titles())
+                    async fn prompts_to_choose_from_pr_titles() -> Result<()> {
+                        let _ = run_async_prompts_to_choose_from_pr_titles().await;
+                        Ok(())
                     }
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn pr_branch_checked_out() -> Result<()> {
-                    let (_, test_repo) = futures::executor::block_on(prep_and_run())?;
+                async fn pr_branch_checked_out() -> Result<()> {
+                    let (_, test_repo) = prep_and_run().await?;
                     assert_eq!(
                         FEATURE_BRANCH_NAME_1,
                         test_repo.get_checked_out_branch_name()?,

--- a/tests/prs_list.rs
+++ b/tests/prs_list.rs
@@ -255,11 +255,10 @@ mod when_main_branch_is_uptodate {
                     Ok(())
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn pr_branch_tip_is_most_recent_patch() -> Result<()> {
-                    let (originating_repo, test_repo) =
-                        futures::executor::block_on(prep_and_run())?;
+                async fn pr_branch_tip_is_most_recent_patch() -> Result<()> {
+                    let (originating_repo, test_repo) = prep_and_run().await?;
                     assert_eq!(
                         originating_repo.get_tip_of_local_branch(FEATURE_BRANCH_NAME_1)?,
                         test_repo.get_tip_of_local_branch(FEATURE_BRANCH_NAME_1)?,
@@ -420,11 +419,10 @@ mod when_main_branch_is_uptodate {
                     Ok(())
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn pr_branch_tip_is_most_recent_patch() -> Result<()> {
-                    let (originating_repo, test_repo) =
-                        futures::executor::block_on(prep_and_run())?;
+                async fn pr_branch_tip_is_most_recent_patch() -> Result<()> {
+                    let (originating_repo, test_repo) = prep_and_run().await?;
                     assert_eq!(
                         originating_repo.get_tip_of_local_branch(FEATURE_BRANCH_NAME_3)?,
                         test_repo.get_tip_of_local_branch(FEATURE_BRANCH_NAME_3)?,
@@ -756,11 +754,10 @@ mod when_main_branch_is_uptodate {
                     Ok(())
                 }
 
-                #[test]
+                #[tokio::test]
                 #[serial]
-                fn pr_branch_tip_is_most_recent_patch() -> Result<()> {
-                    let (originating_repo, test_repo) =
-                        futures::executor::block_on(prep_and_run())?;
+                async fn pr_branch_tip_is_most_recent_patch() -> Result<()> {
+                    let (originating_repo, test_repo) = prep_and_run().await?;
                     assert_eq!(
                         originating_repo.get_tip_of_local_branch(FEATURE_BRANCH_NAME_1)?,
                         test_repo.get_tip_of_local_branch(FEATURE_BRANCH_NAME_1)?,

--- a/tests/pull.rs
+++ b/tests/pull.rs
@@ -396,10 +396,10 @@ mod when_branch_is_checked_out {
             }
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn pr_branch_tip_is_most_recent_patch() -> Result<()> {
-            let (originating_repo, test_repo) = futures::executor::block_on(prep_and_run())?;
+        async fn pr_branch_tip_is_most_recent_patch() -> Result<()> {
+            let (originating_repo, test_repo) = prep_and_run().await?;
             assert_eq!(
                 originating_repo.get_tip_of_local_branch(FEATURE_BRANCH_NAME_1)?,
                 test_repo.get_tip_of_local_branch(FEATURE_BRANCH_NAME_1)?,

--- a/tests/pull.rs
+++ b/tests/pull.rs
@@ -144,10 +144,10 @@ mod when_main_is_checked_out {
             Ok(())
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn cli_show_error() -> Result<()> {
-            futures::executor::block_on(run_async_cli_show_error())
+        async fn cli_show_error() -> Result<()> {
+            run_async_cli_show_error().await
         }
     }
 }
@@ -209,10 +209,10 @@ mod when_branch_doesnt_exist {
             Ok(())
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn cli_show_error() -> Result<()> {
-            futures::executor::block_on(run_async_cli_show_error())
+        async fn cli_show_error() -> Result<()> {
+            run_async_cli_show_error().await
         }
     }
 }
@@ -274,10 +274,10 @@ mod when_branch_is_checked_out {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn cli_show_up_to_date() -> Result<()> {
-                futures::executor::block_on(run_async_cli_show_up_to_date())
+            async fn cli_show_up_to_date() -> Result<()> {
+                run_async_cli_show_up_to_date().await
             }
         }
     }
@@ -389,10 +389,10 @@ mod when_branch_is_checked_out {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn cli_applied_1_commit() -> Result<()> {
-                futures::executor::block_on(run_async_cli_applied_1_commit())
+            async fn cli_applied_1_commit() -> Result<()> {
+                run_async_cli_applied_1_commit().await
             }
         }
 

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -111,6 +111,7 @@ mod when_pr_isnt_associated_with_branch_name {
     use super::*;
 
     mod cli_prompts {
+
         use super::*;
         async fn run_async_cli_show_error() -> Result<()> {
             let (mut r51, mut r52, mut r53, mut r55, mut r56) = (
@@ -164,10 +165,10 @@ mod when_pr_isnt_associated_with_branch_name {
             Ok(())
         }
 
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn cli_show_error() -> Result<()> {
-            futures::executor::block_on(run_async_cli_show_error())
+        async fn cli_show_error() -> Result<()> {
+            run_async_cli_show_error().await
         }
     }
 }
@@ -229,10 +230,11 @@ mod when_branch_is_checked_out {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn cli_show_up_to_date() -> Result<()> {
-                futures::executor::block_on(run_async_cli_show_up_to_date())
+            async fn cli_show_up_to_date() -> Result<()> {
+                let _ = run_async_cli_show_up_to_date().await;
+                Ok(())
             }
         }
     }
@@ -291,10 +293,11 @@ mod when_branch_is_checked_out {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn cli_show_up_to_date() -> Result<()> {
-                futures::executor::block_on(run_async_cli_show_up_to_date())
+            async fn cli_show_up_to_date() -> Result<()> {
+                let _ = run_async_cli_show_up_to_date().await;
+                Ok(())
             }
         }
     }
@@ -389,10 +392,11 @@ mod when_branch_is_checked_out {
                 Ok(())
             }
 
-            #[test]
+            #[tokio::test]
             #[serial]
-            fn cli_applied_1_commit() -> Result<()> {
-                futures::executor::block_on(run_async_cli_applied_1_commit())
+            async fn cli_applied_1_commit() -> Result<()> {
+                let _ = run_async_cli_applied_1_commit().await;
+                Ok(())
             }
         }
 
@@ -453,10 +457,10 @@ mod when_branch_is_checked_out {
 
             Ok((res, r55.events.clone()))
         }
-        #[test]
+        #[tokio::test]
         #[serial]
-        fn commits_issued_as_patch_event() -> Result<()> {
-            let (test_repo, r55_events) = futures::executor::block_on(prep_and_run())?;
+        async fn commits_issued_as_patch_event() -> Result<()> {
+            let (test_repo, r55_events) = prep_and_run().await?;
 
             let commit_id = test_repo
                 .get_tip_of_local_branch(FEATURE_BRANCH_NAME_1)?


### PR DESCRIPTION
as suggested by @DanConwayDev in https://github.com/DanConwayDev/ngit-cli/issues/6#issuecomment-1918971239

PR based on latest `main`, tests are running (almost) well locally now. However, still time-out on tests (rarely). 

All changes made by hand (old school) - no AI as suggested :sweat_smile: 