### PR TITLE
replace relay.nostr.band with nostr.land, as nostr.band is unmaintained

### DIFF
--- a/src/lib/client.rs
+++ b/src/lib/client.rs
@@ -911,7 +911,7 @@ impl Default for Params {
                                                          * known
                                                          * to delete all messages */
                     "wss://nos.lol".to_string(),
-                    "wss://relay.nostr.band".to_string(),
+                    "wss://nostr.land".to_string(),
                 ]
             },
             more_fallback_relays: if std::env::var("NGITTEST").is_ok() {


### PR DESCRIPTION
AFAIK `wss://relay.nostr.band` is unmaintained and when using ngit-cli this relay is giving me time outs.

As a alternative relay, I've added the `wss://nostr.land` relay.