### PR TITLE
fix(pr): avoid fetching from non-nostr git remotes in pr commands

### DIFF
--- a/src/bin/ngit/sub_commands/apply.rs
+++ b/src/bin/ngit/sub_commands/apply.rs
@@ -1,12 +1,6 @@
-use std::{
-    collections::HashSet,
-    io::Write,
-    process::{Command, Stdio},
-    time::Duration,
-};
+use std::{collections::HashSet, io::Write};
 
 use anyhow::{Context, Result, bail};
-use indicatif::{ProgressBar, ProgressStyle};
 use ngit::{
     client::get_all_proposal_patch_pr_pr_update_events_from_cache,
     fetch::fetch_from_git_server,
@@ -26,60 +20,6 @@ use crate::{
     repo_ref::get_repo_coordinates_when_remote_unknown,
 };
 
-fn run_git_fetch(remote_name: &str) -> Result<()> {
-    let verbose = ngit::client::is_verbose();
-    if verbose {
-        println!("fetching from {remote_name}...");
-    }
-
-    let spinner = if verbose {
-        None
-    } else {
-        let pb = ProgressBar::new_spinner()
-            .with_style(
-                ProgressStyle::with_template("{spinner} {msg}")
-                    .unwrap()
-                    .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈"),
-            )
-            .with_message(format!("Fetching from {remote_name}..."));
-        pb.enable_steady_tick(Duration::from_millis(100));
-        Some(pb)
-    };
-
-    let output = Command::new("git")
-        .args(["fetch", remote_name])
-        .stdout(if verbose {
-            Stdio::inherit()
-        } else {
-            Stdio::piped()
-        })
-        .stderr(if verbose {
-            Stdio::inherit()
-        } else {
-            Stdio::piped()
-        })
-        .output()
-        .context("failed to run git fetch")?;
-
-    if let Some(spinner) = spinner {
-        spinner.finish_and_clear();
-    }
-
-    if !output.status.success() {
-        if !verbose {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            if !stderr.is_empty() {
-                eprintln!("{stderr}");
-            }
-        }
-        bail!(
-            "git fetch {remote_name} exited with error: {}",
-            output.status
-        );
-    }
-    Ok(())
-}
-
 pub async fn launch(id: &str, stdout: bool, offline: bool) -> Result<()> {
     let event_id = parse_event_id(id)?;
 
@@ -92,18 +32,8 @@ pub async fn launch(id: &str, stdout: bool, offline: bool) -> Result<()> {
 
     let repo_coordinates = get_repo_coordinates_when_remote_unknown(&git_repo, &client).await?;
 
-    let nostr_remote = git_repo
-        .get_first_nostr_remote_when_in_ngit_binary()
-        .await
-        .ok()
-        .flatten();
-
     if !offline {
-        if let Some((remote_name, _)) = &nostr_remote {
-            run_git_fetch(remote_name)?;
-        } else {
-            fetching_with_report(git_repo_path, &client, &repo_coordinates).await?;
-        }
+        fetching_with_report(git_repo_path, &client, &repo_coordinates).await?;
     }
 
     let repo_ref = get_repo_ref_from_cache(Some(git_repo_path), &repo_coordinates).await?;

--- a/src/bin/ngit/sub_commands/checkout.rs
+++ b/src/bin/ngit/sub_commands/checkout.rs
@@ -1,11 +1,6 @@
-use std::{
-    collections::HashSet,
-    process::{Command, Stdio},
-    time::Duration,
-};
+use std::collections::HashSet;
 
 use anyhow::{Context, Result, bail};
-use indicatif::{ProgressBar, ProgressStyle};
 use ngit::{
     client::{
         Params, get_all_proposal_patch_pr_pr_update_events_from_cache,
@@ -45,11 +40,7 @@ pub async fn launch(id: &str, force: bool, offline: bool) -> Result<()> {
         .flatten();
 
     if !offline {
-        if let Some((remote_name, _)) = &nostr_remote {
-            run_git_fetch(remote_name)?;
-        } else {
-            fetching_with_report(git_repo_path, &client, &repo_coordinates).await?;
-        }
+        fetching_with_report(git_repo_path, &client, &repo_coordinates).await?;
     }
 
     let repo_ref = get_repo_ref_from_cache(Some(git_repo_path), &repo_coordinates).await?;
@@ -100,60 +91,6 @@ pub async fn launch(id: &str, force: bool, offline: bool) -> Result<()> {
             force,
         )
     }
-}
-
-fn run_git_fetch(remote_name: &str) -> Result<()> {
-    let verbose = ngit::client::is_verbose();
-    if verbose {
-        println!("fetching from {remote_name}...");
-    }
-
-    let spinner = if verbose {
-        None
-    } else {
-        let pb = ProgressBar::new_spinner()
-            .with_style(
-                ProgressStyle::with_template("{spinner} {msg}")
-                    .unwrap()
-                    .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈"),
-            )
-            .with_message(format!("Fetching from {remote_name}..."));
-        pb.enable_steady_tick(Duration::from_millis(100));
-        Some(pb)
-    };
-
-    let output = Command::new("git")
-        .args(["fetch", remote_name])
-        .stdout(if verbose {
-            Stdio::inherit()
-        } else {
-            Stdio::piped()
-        })
-        .stderr(if verbose {
-            Stdio::inherit()
-        } else {
-            Stdio::piped()
-        })
-        .output()
-        .context("failed to run git fetch")?;
-
-    if let Some(spinner) = spinner {
-        spinner.finish_and_clear();
-    }
-
-    if !output.status.success() {
-        if !verbose {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            if !stderr.is_empty() {
-                eprintln!("{stderr}");
-            }
-        }
-        bail!(
-            "git fetch {remote_name} exited with error: {}",
-            output.status
-        );
-    }
-    Ok(())
 }
 
 fn parse_event_id(id: &str) -> Result<EventId> {

--- a/src/bin/ngit/sub_commands/list.rs
+++ b/src/bin/ngit/sub_commands/list.rs
@@ -1,13 +1,6 @@
-use std::{
-    collections::HashSet,
-    io::Write,
-    ops::Add,
-    process::{Command, Stdio},
-    time::Duration,
-};
+use std::{collections::HashSet, io::Write, ops::Add};
 
 use anyhow::{Context, Result, bail};
-use indicatif::{ProgressBar, ProgressStyle};
 use ngit::{
     client::{
         Params, get_all_proposal_patch_pr_pr_update_events_from_cache,
@@ -42,60 +35,6 @@ use crate::{
     repo_ref::get_repo_coordinates_when_remote_unknown,
 };
 
-fn run_git_fetch(remote_name: &str) -> Result<()> {
-    let verbose = ngit::client::is_verbose();
-    if verbose {
-        println!("fetching from {remote_name}...");
-    }
-
-    let spinner = if verbose {
-        None
-    } else {
-        let pb = ProgressBar::new_spinner()
-            .with_style(
-                ProgressStyle::with_template("{spinner} {msg}")
-                    .unwrap()
-                    .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈"),
-            )
-            .with_message(format!("Fetching from {remote_name}..."));
-        pb.enable_steady_tick(Duration::from_millis(100));
-        Some(pb)
-    };
-
-    let output = Command::new("git")
-        .args(["fetch", remote_name])
-        .stdout(if verbose {
-            Stdio::inherit()
-        } else {
-            Stdio::piped()
-        })
-        .stderr(if verbose {
-            Stdio::inherit()
-        } else {
-            Stdio::piped()
-        })
-        .output()
-        .context("failed to run git fetch")?;
-
-    if let Some(spinner) = spinner {
-        spinner.finish_and_clear();
-    }
-
-    if !output.status.success() {
-        if !verbose {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            if !stderr.is_empty() {
-                eprintln!("{stderr}");
-            }
-        }
-        bail!(
-            "git fetch {remote_name} exited with error: {}",
-            output.status
-        );
-    }
-    Ok(())
-}
-
 #[allow(clippy::too_many_lines)]
 pub async fn launch(
     status: String,
@@ -116,22 +55,8 @@ pub async fn launch(
 
     let repo_coordinates = get_repo_coordinates_when_remote_unknown(&git_repo, &client).await?;
 
-    let nostr_remote = git_repo
-        .get_first_nostr_remote_when_in_ngit_binary()
-        .await
-        .ok()
-        .flatten();
-
     if !offline {
-        if let Some((remote_name, _)) = &nostr_remote {
-            if std::env::var("NGITTEST").is_ok() {
-                fetching_with_report(git_repo_path, &client, &repo_coordinates).await?;
-            } else {
-                run_git_fetch(remote_name)?;
-            }
-        } else {
-            fetching_with_report(git_repo_path, &client, &repo_coordinates).await?;
-        }
+        fetching_with_report(git_repo_path, &client, &repo_coordinates).await?;
     }
 
     let repo_ref = get_repo_ref_from_cache(Some(git_repo_path), &repo_coordinates).await?;
@@ -694,21 +619,7 @@ async fn launch_interactive() -> Result<()> {
 
     let repo_coordinates = get_repo_coordinates_when_remote_unknown(&git_repo, &client).await?;
 
-    let nostr_remote = git_repo
-        .get_first_nostr_remote_when_in_ngit_binary()
-        .await
-        .ok()
-        .flatten();
-
-    if let Some((remote_name, _)) = &nostr_remote {
-        if std::env::var("NGITTEST").is_ok() {
-            fetching_with_report(git_repo_path, &client, &repo_coordinates).await?;
-        } else {
-            run_git_fetch(remote_name)?;
-        }
-    } else {
-        fetching_with_report(git_repo_path, &client, &repo_coordinates).await?;
-    }
+    fetching_with_report(git_repo_path, &client, &repo_coordinates).await?;
 
     let repo_ref = get_repo_ref_from_cache(Some(git_repo_path), &repo_coordinates).await?;
 


### PR DESCRIPTION
ngit pr list, pr apply, and pr checkout were calling `git fetch <nostr-remote>` as a subprocess. When git processes this fetch, it can also trigger fetches from other remotes configured in .git/config (e.g. GitHub, Codeberg). These fetches are unnecessary for PR operations and inconvenient when those remotes require SSH keys.

These commands only need to refresh nostr event data (proposals, patches, statuses). Replace the subprocess `git fetch` call with `fetching_with_report` which fetches only from nostr relays, matching the pattern used by ngit sync, issue list, pr_status, and other sub-commands.

Git objects (commits) for PR checkout/apply are still fetched from the nostr-registered git servers via fetch_from_git_server when actually needed (i.e., when the tip commit is not yet available locally).